### PR TITLE
Allow back/fw buttons to be placed in navigation bar

### DIFF
--- a/Example/STKWebKitViewController.xcodeproj/project.pbxproj
+++ b/Example/STKWebKitViewController.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
 				4058B53D45EE4EE59CAA47ED /* Copy Pods Resources */,
+				32D1BE9F4D80F9592E68ADC5 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -226,6 +227,7 @@
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
 				9D64680802BF46DB8FE29A5A /* Copy Pods Resources */,
+				CB9C0DAD5F46E0FDA09E5A21 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -294,6 +296,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		32D1BE9F4D80F9592E68ADC5 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-STKWebKitViewController/Pods-STKWebKitViewController-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		4058B53D45EE4EE59CAA47ED /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -352,6 +369,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		CB9C0DAD5F46E0FDA09E5A21 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/STKWebKitViewController/Base.lproj/Main_iPhone.storyboard
+++ b/Example/STKWebKitViewController/Base.lproj/Main_iPhone.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14A388a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="2CP-fX-tm0">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="2CP-fX-tm0">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
@@ -60,6 +60,15 @@
                                     <action selector="openWithCustomColors:" destination="nd3-Ga-YNe" eventType="touchUpInside" id="n9K-Dg-X1W"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="atR-Jy-2nL">
+                                <rect key="frame" x="82" y="455" width="167" height="30"/>
+                                <state key="normal" title="Modally with custom NC">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="openModallyWithCustomNC:" destination="nd3-Ga-YNe" eventType="touchUpInside" id="BeD-DT-OQY"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
@@ -70,9 +79,4 @@
             <point key="canvasLocation" x="1152" y="143"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>

--- a/Example/STKWebKitViewController/STKViewController.m
+++ b/Example/STKWebKitViewController/STKViewController.m
@@ -33,6 +33,14 @@
     [self presentViewController:controller animated:YES completion:nil];
 }
 
+- (IBAction)openModallyWithCustomNC:(UIButton *)sender {
+	NSURL *url = [NSURL URLWithString:@"https://github.com/sticksen/STKWebKitViewController"];
+	STKWebKitViewController *controller = [[STKWebKitViewController alloc] initWithURL:url];
+	controller.controlItemsPosition = STKWebKitControlItemsPositionNavigationBar;
+	UINavigationController *nc = [[UINavigationController alloc] initWithRootViewController:controller];
+	[self presentViewController:nc animated:YES completion:nil];
+}
+
 - (IBAction)pushOnNavController:(UIButton *)sender {
     NSURL *url = [NSURL URLWithString:@"https://github.com/sticksen/STKWebKitViewController"];
     STKWebKitViewController *controller = [[STKWebKitViewController alloc] initWithURL:url];

--- a/Pod/Classes/STKWebKitViewController.h
+++ b/Pod/Classes/STKWebKitViewController.h
@@ -17,6 +17,11 @@ typedef enum {
     OpenNewTabInternal
 } NewTabOpenMode;
 
+typedef NS_ENUM(NSInteger, STKWebKitControlItemsPosition) {
+	STKWebKitControlItemsPositionBottomToolbar,
+	STKWebKitControlItemsPositionNavigationBar	//	back/fw/reload will be show in the navigation bar
+};
+
 @interface STKWebKitViewController : UIViewController <WKNavigationDelegate>
 
 + (NSBundle *)bundle;
@@ -42,7 +47,9 @@ typedef enum {
 /** use this to customize the UIActivityViewController (aka Sharing-Dialog) */
 @property (nonatomic) NSArray *applicationActivities;
 
-
 /*** use this to specify schemes that should be handled directly by the app ***/
 @property (strong, nonatomic) NSArray *customSchemes;
+
+@property (nonatomic) STKWebKitControlItemsPosition controlItemsPosition;
+
 @end

--- a/Pod/Classes/STKWebKitViewController.h
+++ b/Pod/Classes/STKWebKitViewController.h
@@ -50,6 +50,9 @@ typedef NS_ENUM(NSInteger, STKWebKitControlItemsPosition) {
 /*** use this to specify schemes that should be handled directly by the app ***/
 @property (strong, nonatomic) NSArray *customSchemes;
 
+- (void)fillToolbar;
+- (void)populateNavigationBar;
+
 @property (nonatomic) STKWebKitControlItemsPosition controlItemsPosition;
 
 @end

--- a/Pod/Classes/STKWebKitViewController.m
+++ b/Pod/Classes/STKWebKitViewController.m
@@ -71,6 +71,8 @@
     if (self = [super initWithNibName:nil bundle:nil]) {
         NSAssert([[UIDevice currentDevice].systemVersion floatValue] >= 8.0, @"WKWebView is available since iOS8. Use UIWebView, if you´re running an older version");
         NSAssert([NSThread isMainThread], @"WebKit is not threadsafe and this function is not executed on the main thread");
+
+		_controlItemsPosition = STKWebKitControlItemsPositionBottomToolbar;
         
         self.newTabOpenMode = OpenNewTabExternal;
         self.request = request;
@@ -101,25 +103,34 @@
     NSAssert(self.navigationController, @"STKWebKitViewController needs to be contained in a UINavigationController. If you are presenting STKWebKitViewController modally, use STKModalWebKitViewController instead.");
     
     [self.view setNeedsUpdateConstraints];
-    self.toolbarWasHidden = self.navigationController.isToolbarHidden;
-    [self.navigationController setToolbarHidden:NO animated:YES];
-    [self fillToolbar];
-    
+
+	if (self.controlItemsPosition == STKWebKitControlItemsPositionBottomToolbar) {
+		self.toolbarWasHidden = self.navigationController.isToolbarHidden;
+		[self.navigationController setToolbarHidden:NO animated:YES];
+		[self fillToolbar];
+		self.savedToolbarTintColor = self.navigationController.toolbar.barTintColor;
+		self.savedToolbarItemTintColor = self.navigationController.toolbar.tintColor;
+
+		if (self.toolbarTintColor) {
+			self.navigationController.toolbar.barTintColor = self.toolbarTintColor;
+			self.navigationController.toolbar.backgroundColor = self.toolbarTintColor;
+			self.navigationController.toolbar.tintColor = [UIColor whiteColor];
+		}
+		if (self.toolbarItemTintColor) {
+			self.navigationController.toolbar.tintColor = self.toolbarItemTintColor;
+		}
+	} else {
+		[self setToolbarItems:nil];
+	}
+
     self.savedNavigationbarTintColor = self.navigationController.navigationBar.barTintColor;
-    self.savedToolbarTintColor = self.navigationController.toolbar.barTintColor;
-    self.savedToolbarItemTintColor = self.navigationController.toolbar.tintColor;
-    
-    if (self.toolbarTintColor) {
-        self.navigationController.toolbar.barTintColor = self.toolbarTintColor;
-        self.navigationController.toolbar.backgroundColor = self.toolbarTintColor;
-        self.navigationController.toolbar.tintColor = [UIColor whiteColor];
-    }
-    if (self.toolbarItemTintColor) {
-        self.navigationController.toolbar.tintColor = self.toolbarItemTintColor;
-    }
     if (self.navigationBarTintColor) {
         self.navigationController.navigationBar.barTintColor = self.navigationBarTintColor;
     }
+
+	if (self.controlItemsPosition == STKWebKitControlItemsPositionNavigationBar) {
+		[self populateNavigationBar];
+	}
     
     [self addObserver:self forKeyPath:@"webView.title" options:NSKeyValueObservingOptionNew context:NULL];
     [self addObserver:self forKeyPath:@"webView.loading" options:NSKeyValueObservingOptionNew context:NULL];
@@ -182,12 +193,61 @@
     [self setToolbarItems:@[flexibleSpaceItem, backItem, flexibleSpaceItem, forwardItem, flexibleSpaceItem, reloadItem, flexibleSpaceItem, shareItem, flexibleSpaceItem] animated:NO];
 }
 
+- (void)populateNavigationBar {
+	UIBarButtonItem *backItem = [[UIBarButtonItem alloc] initWithImage:[self imageNamed:@"back" ] style:UIBarButtonItemStylePlain target:self action:@selector(backTapped:)];
+	if (self.webView.canGoBack) {
+		backItem.tintColor = nil;
+	} else {
+		backItem.tintColor = [UIColor lightGrayColor];
+	}
+
+	UIBarButtonItem *forwardItem = [[UIBarButtonItem alloc] initWithImage:[self imageNamed:@"forward"] style:UIBarButtonItemStylePlain target:self action:@selector(forwardTapped:)];
+	if (self.webView.canGoForward) {
+		forwardItem.tintColor = nil;
+	} else {
+		forwardItem.tintColor = [UIColor lightGrayColor];
+	}
+
+	UIBarButtonItem *reloadItem;
+	if (self.webView.isLoading) {
+		reloadItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemStop target:self action:@selector(stopTapped:)];
+	} else {
+		reloadItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh target:self action:@selector(reloadTapped:)];
+	}
+
+	UIBarButtonItem *shareItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(shareTapped:)];
+
+	UIBarButtonItem *closeItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(close:)];
+
+	self.navigationItem.leftBarButtonItems = @[ backItem, forwardItem, reloadItem ];
+	self.navigationItem.rightBarButtonItems = @[ closeItem, shareItem ];
+}
+
+- (void)close:(UIButton *)sender {
+
+	if (self.presentingViewController) {
+		[self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+		return;
+	}
+
+	[self.navigationController popViewControllerAnimated:YES];
+}
+
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
     if ([keyPath isEqualToString:@"webView.title"]) {
         self.title = change[@"new"];
     } else if ([keyPath isEqualToString:@"webView.loading"]) {
-        [self fillToolbar];
+		switch (self.controlItemsPosition) {
+			case STKWebKitControlItemsPositionBottomToolbar: {
+				[self fillToolbar];
+				break;
+			}
+			case STKWebKitControlItemsPositionNavigationBar: {
+				[self populateNavigationBar];
+				break;
+			}
+		}
     } else if ([keyPath isEqualToString:@"webView.estimatedProgress"]) {
 
     }

--- a/Pod/Classes/STKWebKitViewController.m
+++ b/Pod/Classes/STKWebKitViewController.m
@@ -73,7 +73,7 @@
         NSAssert([NSThread isMainThread], @"WebKit is not threadsafe and this function is not executed on the main thread");
 
 		_controlItemsPosition = STKWebKitControlItemsPositionBottomToolbar;
-        
+
         self.newTabOpenMode = OpenNewTabExternal;
         self.request = request;
         if (script) {
@@ -195,18 +195,10 @@
 
 - (void)populateNavigationBar {
 	UIBarButtonItem *backItem = [[UIBarButtonItem alloc] initWithImage:[self imageNamed:@"back" ] style:UIBarButtonItemStylePlain target:self action:@selector(backTapped:)];
-	if (self.webView.canGoBack) {
-		backItem.tintColor = nil;
-	} else {
-		backItem.tintColor = [UIColor lightGrayColor];
-	}
+	backItem.enabled = self.webView.canGoBack;
 
 	UIBarButtonItem *forwardItem = [[UIBarButtonItem alloc] initWithImage:[self imageNamed:@"forward"] style:UIBarButtonItemStylePlain target:self action:@selector(forwardTapped:)];
-	if (self.webView.canGoForward) {
-		forwardItem.tintColor = nil;
-	} else {
-		forwardItem.tintColor = [UIColor lightGrayColor];
-	}
+	forwardItem.enabled = self.webView.canGoForward;
 
 	UIBarButtonItem *reloadItem;
 	if (self.webView.isLoading) {


### PR DESCRIPTION
I added an option to choose where the web browser control buttons (back, fw. share etc) located. By default it stays in the toolbar at the bottom, but you can also choose to have htem at the top, inside navigation bar.

Also, moved some methods to the interface, so the subclassing is easier and you can change the buttons to your liking.